### PR TITLE
Add option for fields without escaping

### DIFF
--- a/src/Data/Csv.hs
+++ b/src/Data/Csv.hs
@@ -46,6 +46,7 @@ module Data.Csv
     -- ** Encoding and decoding options
     -- $options
     , DecodeOptions(..)
+    , Escaping(..)
     , defaultDecodeOptions
     , decodeWith
     , decodeWithP

--- a/src/Data/Csv/Encoding.hs
+++ b/src/Data/Csv/Encoding.hs
@@ -22,6 +22,7 @@ module Data.Csv.Encoding
 
     -- ** Encoding and decoding options
     , DecodeOptions(..)
+    , Escaping (..)
     , defaultDecodeOptions
     , decodeWith
     , decodeWithP

--- a/src/Data/Csv/Incremental.hs
+++ b/src/Data/Csv/Incremental.hs
@@ -176,7 +176,7 @@ decodeHeader = decodeHeaderWith defaultDecodeOptions
 decodeHeaderWith :: DecodeOptions -> HeaderParser B.ByteString
 decodeHeaderWith !opts = PartialH (go . parser)
   where
-    parser = A.parse (header $ decDelimiter opts)
+    parser = A.parse $ header (decDelimiter opts) (decEscape opts)
 
     go (A.Fail rest _ msg) = FailH rest err
       where err = "parse error (" ++ msg ++ ")"
@@ -329,7 +329,8 @@ decodeWithP' p !opts = go Incomplete [] . parser
             acc' | blankLine r = acc
                  | otherwise   = let !r' = convert r in r' : acc
 
-    parser = A.parse (record (decDelimiter opts) <* (endOfLine <|> endOfInput))
+    parser = A.parse $
+      record (decDelimiter opts) (decEscape opts) <* (endOfLine <|> endOfInput)
     convert = runParser . p
 {-# INLINE decodeWithP' #-}
 

--- a/src/Data/Csv/Parser.hs
+++ b/src/Data/Csv/Parser.hs
@@ -5,7 +5,7 @@
 --
 --  * Empty lines are ignored.
 --
--- When 'decEscape' is set to 'Escape':
+-- When 'decEscape' is set to 'MaybeEscape':
 --
 --  * Non-escaped fields may contain any characters except
 --    double-quotes, delimiters, carriage returns, and newlines.
@@ -54,8 +54,8 @@ import Data.Monoid (mappend, mempty)
 
 -- | Whether to escape fields with double quotes (@"@).
 data Escaping
-    = Escape
-      -- ^ Parse possible escaped fields. The delimiter can appear in
+    = MaybeEscape
+      -- ^ Parse possibly escaped fields. The delimiter can appear in
       -- fields surrounded by double quotes; to write a double quote
       -- character inside an escaped field, you must use two double
       -- quote characters (@""@).
@@ -86,7 +86,7 @@ data DecodeOptions = DecodeOptions
 defaultDecodeOptions :: DecodeOptions
 defaultDecodeOptions = DecodeOptions
     { decDelimiter = 44  -- comma
-    , decEscape    = Escape
+    , decEscape    = MaybeEscape
     }
 
 -- | Parse a CSV file that does not include a header.
@@ -170,14 +170,14 @@ record !delim !escape = V.fromList <$!> field delim escape `sepByDelim1'` delim
 field :: Word8     -- ^ Field delimiter
       -> Escaping  -- ^ Escape
       -> AL.Parser Field
-field !delim Escape = fieldEscape delim
+field !delim MaybeEscape = fieldMaybeEscape delim
 field !delim NoEscape = fieldNoEscape delim
 {-# INLINE field #-}
 
 -- | Parse a field that may be in either the escaped or non-escaped
 -- format. The return value is unescaped.
-fieldEscape :: Word8 -> AL.Parser Field
-fieldEscape !delim = do
+fieldMaybeEscape :: Word8 -> AL.Parser Field
+fieldMaybeEscape !delim = do
     mb <- A.peekWord8
     -- We purposely don't use <|> as we want to commit to the first
     -- choice if we see a double quote.

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -11,6 +11,7 @@ module Main
     ) where
 
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.HashMap.Strict as HM
@@ -188,8 +189,9 @@ positionalTests =
         ]
     decodeWithTests =
         [ ("tab-delim", defDec { decDelimiter = 9 }, "1\t2", [["1", "2"]])
-        , ("no-escape", defDec { decEscape = NoEscape }, "\"a,b\",\"c\nd,e,f\"",
-           [["\"a", "b\"", "\"c"], ["d", "e", "f\""]])
+        , ("no-escape", defDec { decEscape = NoEscape },
+           BL8.map replaceQuote "'a,b','c\nd,e,f'",
+           map (map $ B8.map replaceQuote) [["'a", "b'", "'c"], ["d", "e", "f'"]])
         ]
 
     encodeTest (name, input, expected) =
@@ -210,6 +212,11 @@ positionalTests =
     defEncNoneEnq = defaultEncodeOptions { encQuoting = QuoteNone }
     defEncAllEnq  = defaultEncodeOptions { encQuoting = QuoteAll  }
     defDec = defaultDecodeOptions
+
+    -- Replace single quotes by double quotes.
+    replaceQuote :: Char -> Char
+    replaceQuote '\'' = '"'
+    replaceQuote c = c
 
 nameBasedTests :: [TF.Test]
 nameBasedTests =

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -188,6 +188,8 @@ positionalTests =
         ]
     decodeWithTests =
         [ ("tab-delim", defDec { decDelimiter = 9 }, "1\t2", [["1", "2"]])
+        , ("no-escape", defDec { decEscape = False }, "\"a,b\",\"c\nd,e,f\"",
+           [["\"a", "b\"", "\"c"], ["d", "e", "f\""]])
         ]
 
     encodeTest (name, input, expected) =

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -188,7 +188,7 @@ positionalTests =
         ]
     decodeWithTests =
         [ ("tab-delim", defDec { decDelimiter = 9 }, "1\t2", [["1", "2"]])
-        , ("no-escape", defDec { decEscape = False }, "\"a,b\",\"c\nd,e,f\"",
+        , ("no-escape", defDec { decEscape = NoEscape }, "\"a,b\",\"c\nd,e,f\"",
            [["\"a", "b\"", "\"c"], ["d", "e", "f\""]])
         ]
 


### PR DESCRIPTION
This pull request adds an option for parsing fields without any escaping. See the Haddock documentation for more information.